### PR TITLE
switches vnu execution to execa

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,15 +2,15 @@
 
 module.exports = {
   root: true,
-  "extends": "plugin:@phanect/ts",
+  extends: "plugin:@phanect/plain",
 
-  "env": {
-    "browser": false,
-    "node": true
+  env: {
+    browser: false,
+    node: true,
   },
 
   parserOptions: {
     project: "./tsconfig.json",
   },
-  plugins: [ "@phanect" ]
+  plugins: [ "@phanect" ],
 };

--- a/package.json
+++ b/package.json
@@ -28,23 +28,22 @@
   },
   "homepage": "https://github.com/phanect/vnujs",
   "dependencies": {
-    "tmp-promise": "^3.0.2",
-    "vnu-jar": "20.6.30"
+    "vnu-jar": "21.4.9"
   },
   "devDependencies": {
-    "@phanect/eslint-plugin": "latest",
-    "@types/chai": "^4.2.2",
+    "@phanect/eslint-plugin": "^2021.4.25",
+    "@types/chai": "^4.2.18",
     "@types/express": "^4.17.1",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^14.0.1",
+    "@types/node": "^15.6.1",
     "@types/tmp": "^0.2.0",
     "@types/vnu-jar": "^17.11.0",
-    "chai": "^4.1.2",
+    "chai": "^4.3.4",
     "eslint": "latest",
     "eslint-plugin-chai-friendly": "latest",
     "express": "^4.17.1",
     "mocha": "^7.1.2",
     "ts-mocha": "^7.0.0",
-    "typescript": "^3.5.3"
+    "typescript": "^4.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   },
   "homepage": "https://github.com/phanect/vnujs",
   "dependencies": {
+    "execa": "^5.0.1",
+    "promisify-child-process": "^4.1.1",
     "vnu-jar": "21.4.9"
   },
   "devDependencies": {

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -4,13 +4,13 @@ const { join } = require("path");
 
 module.exports = {
   env: {
-    mocha: true
+    mocha: true,
   },
   parserOptions: {
     project: join(__dirname, "tsconfig.json"),
   },
   plugins: [
-    "chai-friendly"
+    "chai-friendly",
   ],
   rules: {
     "prefer-arrow-callback": "off",


### PR DESCRIPTION
I encountered some errors while providing raw input strings to this module. So I switched to [`execa`](https://github.com/sindresorhus/execa) to provide the input as `stdin`. This is much safer and should not throw any errors again. Additionally this simplifies some parts of the code. I also set `"exit-zero-always": true` and `stdout: true` to let the promise handle any errors.